### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/include/sections/dialogs.php
+++ b/include/sections/dialogs.php
@@ -821,7 +821,7 @@
         CA Conway, BC Jones, LM DeBruine, AC Little & A Sahraie (2008). Transient 
         pupil constrictions to faces are sensitive to orientation and species. 
         <i>Journal of Vision</i>, 8(3): 17. 
-        <a href="http://dx.doi.org/10.1167/8.3.17" target="_blank">doi: 10.1167/8.3.17</a>
+        <a href="https://doi.org/10.1167/8.3.17" target="_blank">doi: 10.1167/8.3.17</a>
     </p>
     <h3>To cite (or download) provided images</h3>
     <p><img src="/include/images/demos/london2017.jpg"><br>
@@ -842,7 +842,7 @@
         <img src="/include/examples/m_white">
         <img src="/include/examples/m_multi"><br>
         DeBruine, Lisa (2016). Young adult composite faces. <i>figshare</i>. 
-        <a href="https://dx.doi.org/10.6084/m9.figshare.4055130.v1" 
+        <a href="https://doi.org/10.6084/m9.figshare.4055130.v1" 
             target="_blank">doi: 10.6084/m9.figshare.4055130.v1</a>
     </p>
     <p><img src="/include/images/demos/canada2003.jpg"><br>

--- a/include/sections/login.php
+++ b/include/sections/login.php
@@ -156,7 +156,7 @@
         CA Conway, BC Jones, LM DeBruine, AC Little & A Sahraie (2008). Transient 
         pupil constrictions to faces are sensitive to orientation and species. 
         <i>Journal of Vision</i>, 8(3): 17. 
-        <a href="http://dx.doi.org/10.1167/8.3.17" target="_blank">doi: 10.1167/8.3.17</a>
+        <a href="https://doi.org/10.1167/8.3.17" target="_blank">doi: 10.1167/8.3.17</a>
     </p>
     
     <p class="cite">
@@ -171,7 +171,7 @@
         <img src="/include/examples/m_white">
         <img src="/include/examples/m_multi"><br>
         DeBruine, Lisa (2016). Young adult composite faces. <i>figshare</i>. 
-        <a href="https://dx.doi.org/10.6084/m9.figshare.4055130.v1" 
+        <a href="https://doi.org/10.6084/m9.figshare.4055130.v1" 
             target="_blank">doi:10.6084/m9.figshare.4055130.v1</a>
     </p>
     


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!